### PR TITLE
Conforms with Catch2 v3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,67 +38,8 @@ if( NOT TARGET tlapack )
 endif()
 
 # Load Catch2
-find_package( Catch2 QUIET HINTS ${Catch2_DIR} ) # Try to load Catch2 from the system
-if( NOT Catch2_FOUND )
-
-  if  ( EXISTS "${Catch2_DIR}/include/catch.hpp" )
-
-    add_subdirectory( ${Catch2_DIR} ${CMAKE_CURRENT_BINARY_DIR}/Catch2 )
-    message( STATUS "Using Catch2 from ${Catch2_DIR}" )
-
-    # Add folder with Catch.cmake to the CMAKE_MODULE_PATH
-    set( CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH};${Catch2_DIR}/extras;${Catch2_DIR}/contrib" )
-
-  elseif( EXISTS "$ENV{Catch2_DIR}/include/catch.hpp" )
-
-    get_property( docString CACHE Catch2_DIR PROPERTY HELPSTRING )
-    set( Catch2_DIR $ENV{Catch2_DIR} CACHE STRING "${docString}" FORCE )
-    add_subdirectory( ${Catch2_DIR} ${CMAKE_CURRENT_BINARY_DIR}/Catch2 )
-    message( STATUS "Using Catch2 from ${Catch2_DIR}" )
-
-    # Add folder with Catch.cmake to the CMAKE_MODULE_PATH
-    set( CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH};${Catch2_DIR}/extras;${Catch2_DIR}/contrib" )
-
-  elseif( ${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.14" )
-
-    message( STATUS "Catch2 not found. Trying to fetch from https://github.com/catchorg/Catch2.git. "
-                    "It may take a while." )
-
-    include(FetchContent)
-    FetchContent_Declare(
-      Catch2
-      GIT_REPOSITORY https://github.com/catchorg/Catch2.git
-      GIT_TAG        v2.13.1 )
-
-    FetchContent_MakeAvailable(Catch2)
-
-    # Add folder with Catch.cmake to the CMAKE_MODULE_PATH
-    set( CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH};${Catch2_SOURCE_DIR}/extras;${Catch2_SOURCE_DIR}/contrib" )
-
-    # Test if the fetch was successful
-    if( EXISTS "${Catch2_SOURCE_DIR}/include/catch.hpp" )
-      message( STATUS "Using Catch2 from https://github.com/catchorg/Catch2.git." )
-    else()
-      message( FATAL_ERROR "Failed in fetching Catch2 from https://github.com/catchorg/Catch2.git." )
-    endif()
-
-    # Hide Catch2_DIR, CATCH_ and FETCHCONTENT_ options
-    mark_as_advanced( FORCE Catch2_DIR )
-    get_cmake_property(_variableNames VARIABLES)
-    foreach (_variableName ${_variableNames})
-      if( "${_variableName}" MATCHES "^CATCH_" OR
-          "${_variableName}" MATCHES "^FETCHCONTENT_" )
-        mark_as_advanced( FORCE ${_variableName} )
-      endif()
-    endforeach()
-
-  else()
-    message( FATAL_ERROR "Catch2 not found. Set \"Catch2_DIR\" to a directory containing either
-    (1) \"include/catch.hpp\",
- or (2) one of the files: Catch2Config.cmake, catch2-config.cmake." )
-  endif()
-
-endif( NOT Catch2_FOUND )
+include( "${testBLAS_SOURCE_DIR}/cmake/FetchPackage.cmake" )
+FetchPackage( "Catch2" "https://github.com/catchorg/Catch2.git" "devel" )
 
 # Search for MPFR library if TEST_MPFR = ON
 if( TEST_MPFR )
@@ -139,10 +80,10 @@ file( GLOB test_sources
 
 if( NOT TARGET tester )
 
-  add_executable( tester tests_main.cpp ${test_sources} )
+  add_executable( tester ${test_sources} )
 
   target_include_directories( tester PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/include" )
-  target_link_libraries( tester PRIVATE Catch2::Catch2 tblas )
+  target_link_libraries( tester PRIVATE Catch2::Catch2WithMain tblas )
 
   if( TEST_MPFR )
     target_compile_definitions( tester PRIVATE USE_MPFR )

--- a/cmake/FetchPackage.cmake
+++ b/cmake/FetchPackage.cmake
@@ -1,0 +1,52 @@
+# FetchPackage tries to load ${pkg} using:
+# 1. The usual CMake find_package
+# 2. An online Git repository via the CMake FetchContent module
+#
+# Copyright (c) 2022, University of Colorado Denver. All rights reserved.
+#
+# This file is part of testBLAS.
+# testBLAS is free software: you can redistribute it and/or modify it under
+# the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
+
+macro( FetchPackage pkg pkgURL gitTag )
+
+  find_package( ${pkg} QUIET ) # Try to load ${pkg} from the system
+  if( NOT ${pkg}_FOUND )
+
+    if( ${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.14" )
+
+      message( STATUS "${pkg} not found. Trying to fetch from ${pkgURL}. "
+                      "It may take a while." )
+
+      include(FetchContent)
+      FetchContent_Declare(
+      ${pkg}
+      GIT_REPOSITORY ${pkgURL}
+      GIT_TAG        ${gitTag} )
+
+      FetchContent_MakeAvailable(${pkg})
+
+      # Test if the fetch was successful
+      if( EXISTS "${${pkg}_SOURCE_DIR}" )
+        message( STATUS "Using ${pkg} from ${pkgURL}." )
+      else()
+        message( FATAL_ERROR "Failed in fetching ${pkg} from ${pkgURL}." )
+      endif()
+
+      # Hide ${pkg}_DIR and FETCHCONTENT_ options
+      mark_as_advanced( FORCE ${pkg}_DIR )
+      get_cmake_property(_variableNames VARIABLES)
+      foreach (_variableName ${_variableNames})
+      if( "${_variableName}" MATCHES "^FETCHCONTENT_" )
+          mark_as_advanced( FORCE ${_variableName} )
+      endif()
+      endforeach()
+
+    else()
+      message( FATAL_ERROR "${pkg} not found. Set \"${pkg}_DIR\" to a directory containing "
+                      "one of the files: ${pkg}Config.cmake, ${pkg}-config.cmake." )
+    endif()
+
+  endif( NOT ${pkg}_FOUND )
+    
+endmacro()

--- a/scripts/wrapper_tests.py
+++ b/scripts/wrapper_tests.py
@@ -89,7 +89,7 @@ print("""\
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
 #include <type_traits>
-#include <catch2/catch.hpp>
+#include <catch2/catch_template_test_macros.hpp>
 #include <legacy_api/blas.hpp>
 #include "defines.hpp"
 #ifdef USE_MPFR

--- a/src/test_corner_cases.cpp
+++ b/src/test_corner_cases.cpp
@@ -11,7 +11,7 @@
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
 #include <type_traits>
-#include <catch2/catch.hpp>
+#include <catch2/catch_template_test_macros.hpp>
 #include <legacy_api/blas.hpp>
 #include "defines.hpp"
 #ifdef USE_MPFR

--- a/src/test_infNaN.cpp
+++ b/src/test_infNaN.cpp
@@ -7,7 +7,7 @@
 #include "defines.hpp"
 #include "utils.hpp"
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_template_test_macros.hpp>
 #include <limits>
 #include <iostream>
 

--- a/src/test_infNaN_iamax.cpp
+++ b/src/test_infNaN_iamax.cpp
@@ -7,7 +7,7 @@
 // testBLAS is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_template_test_macros.hpp>
 #include <legacy_api/blas.hpp>
 #include "defines.hpp"
 #include "utils.hpp"

--- a/src/test_infNaN_nrm2.cpp
+++ b/src/test_infNaN_nrm2.cpp
@@ -14,7 +14,7 @@
     #include <plugins/tlapack_mpreal.hpp>
 #endif
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_template_test_macros.hpp>
 #include <limits>
 #include <vector>
 #include <complex>

--- a/src/test_infNaN_trsv_trsm.cpp
+++ b/src/test_infNaN_trsv_trsm.cpp
@@ -10,7 +10,7 @@
 #include "defines.hpp"
 #include "utils.hpp"
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_template_test_macros.hpp>
 #include <limits>
 #include <vector>
 #include <complex>

--- a/tests_main.cpp
+++ b/tests_main.cpp
@@ -1,8 +1,0 @@
-// Copyright (c) 2021, University of Colorado Denver. All rights reserved.
-//
-// This file is part of testBLAS.
-// testBLAS is free software: you can redistribute it and/or modify it under
-// the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
-
-#define CATCH_CONFIG_MAIN
-#include <catch2/catch.hpp>


### PR DESCRIPTION
From https://github.com/catchorg/Catch2/blob/devel/docs/migrate-v2-to-v3.md :

> There are many reasons why we decided to go from the old single-header distribution model to a more standard library distribution model. The big one is compile-time performance, but moving over to a split header distribution model also improves the future maintainability and extendability of the codebase.